### PR TITLE
`StateToTpl`: using `jsonencode` for valid json string value of object/array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.vscode

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/google/go-cmp v0.5.8
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/hc-install v0.4.0
 	github.com/hashicorp/hcl/v2 v2.13.0
 	github.com/hashicorp/terraform-exec v0.17.2
@@ -31,6 +30,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-checkpoint v0.5.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/tfadd/internal/state_to_tpl.go
+++ b/tfadd/internal/state_to_tpl.go
@@ -88,14 +88,14 @@ func addAttributes(buf *strings.Builder, stateVal cty.Value, attrs map[string]*t
 			tok := hclwrite.TokensForValue(val)
 			// use jsonencode if val is valid json object
 			bs := tok.Bytes()
-			if val.Type().Equals(cty.String) {
-				if jsonStr, err := strconv.Unquote(string(bs)); err == nil && len(jsonStr) > 0 {
-					jsonBytes := []byte(jsonStr)
-					if (jsonBytes[0] == '{' || jsonBytes[0] == '[') && json.Valid(jsonBytes) {
+			if attrS.AttributeType.Equals(cty.String) {
+				if unquoted, err := strconv.Unquote(string(bs)); err == nil && len(unquoted) > 0 {
+					if (unquoted[0] == '{' || unquoted[0] == '[') && json.Valid([]byte(unquoted)) {
 						var jsonObj interface{}
-						_ = json.Unmarshal(jsonBytes, &jsonObj)
-						jsonBytes, _ = json.MarshalIndent(jsonObj, strings.Repeat(" ", indent), "  ")
-						bs = append([]byte("jsonencode("), append(jsonBytes, ')')...)
+						// ignore error here, as we have already validated the json string
+						json.Unmarshal([]byte(unquoted), &jsonObj)
+						indentBs, _ := json.MarshalIndent(jsonObj, strings.Repeat(" ", indent), "  ")
+						bs = append([]byte("jsonencode("), append(indentBs, ')')...)
 					}
 				}
 			}

--- a/tfadd/internal/state_to_tpl_test.go
+++ b/tfadd/internal/state_to_tpl_test.go
@@ -20,6 +20,7 @@ func Test_StateToTpl(t *testing.T) {
 				"mount_point": cty.StringVal("/mnt/foo"),
 				"size":        cty.StringVal("50GB"),
 			}),
+			"list_str": cty.StringVal(`[1, 2, 3]`),
 			"foo_list": cty.ListVal([]cty.Value{
 				cty.NumberIntVal(1),
 				cty.NumberIntVal(2),
@@ -43,6 +44,7 @@ func Test_StateToTpl(t *testing.T) {
     foo = "bar"
   })
   foo_list = [1, 2, 3]
+  list_str = jsonencode([1, 2, 3])
 }
 `
 	if string(b) != expected {
@@ -303,6 +305,7 @@ func addTestSchema(nesting tfjson.SchemaNestingMode) *tfjson.SchemaBlock {
 					NestingMode: nesting,
 				},
 			},
+			"list_str": {AttributeType: cty.String, Optional: true},
 			"foo_list": {AttributeType: cty.List(cty.Number), Optional: true},
 			"foo_json": {AttributeType: cty.String, Optional: true},
 		},

--- a/tfadd/internal/state_to_tpl_test.go
+++ b/tfadd/internal/state_to_tpl_test.go
@@ -40,7 +40,7 @@ func Test_StateToTpl(t *testing.T) {
     size        = "50GB"
   }
   foo_json = jsonencode({
-    "foo" : "bar"
+    foo = "bar"
   })
   foo_list = [1, 2, 3]
 }

--- a/tfadd/internal/state_to_tpl_test.go
+++ b/tfadd/internal/state_to_tpl_test.go
@@ -26,7 +26,7 @@ func Test_StateToTpl(t *testing.T) {
 				cty.NumberIntVal(2),
 				cty.NumberIntVal(3),
 			}),
-			"foo_json": cty.StringVal(`{"foo": "bar"}`),
+			"foo_json": cty.StringVal(`{"foo": "bar", "block1": { "foo2": "bar2"}}`),
 		}),
 	}
 	b, err := StateToTpl(res, addTestSchema(tfjson.SchemaNestingModeSingle))
@@ -41,6 +41,9 @@ func Test_StateToTpl(t *testing.T) {
     size        = "50GB"
   }
   foo_json = jsonencode({
+    block1 = {
+      foo2 = "bar2"
+    }
     foo = "bar"
   })
   foo_list = [1, 2, 3]

--- a/tfadd/internal/state_to_tpl_test.go
+++ b/tfadd/internal/state_to_tpl_test.go
@@ -20,6 +20,12 @@ func Test_StateToTpl(t *testing.T) {
 				"mount_point": cty.StringVal("/mnt/foo"),
 				"size":        cty.StringVal("50GB"),
 			}),
+			"foo_list": cty.ListVal([]cty.Value{
+				cty.NumberIntVal(1),
+				cty.NumberIntVal(2),
+				cty.NumberIntVal(3),
+			}),
+			"foo_json": cty.StringVal(`{"foo": "bar"}`),
 		}),
 	}
 	b, err := StateToTpl(res, addTestSchema(tfjson.SchemaNestingModeSingle))
@@ -33,6 +39,10 @@ func Test_StateToTpl(t *testing.T) {
     mount_point = "/mnt/foo"
     size        = "50GB"
   }
+  foo_json = jsonencode({
+    "foo" : "bar"
+  })
+  foo_list = [1, 2, 3]
 }
 `
 	if string(b) != expected {
@@ -293,6 +303,8 @@ func addTestSchema(nesting tfjson.SchemaNestingMode) *tfjson.SchemaBlock {
 					NestingMode: nesting,
 				},
 			},
+			"foo_list": {AttributeType: cty.List(cty.Number), Optional: true},
+			"foo_json": {AttributeType: cty.String, Optional: true},
 		},
 		NestedBlocks: map[string]*tfjson.SchemaBlockType{
 			"root_block_device": {

--- a/tfadd/internal/tune_tpl.go
+++ b/tfadd/internal/tune_tpl.go
@@ -83,7 +83,6 @@ func tuneForBlock(rb *hclwrite.Body, sch *tfpluginschema.Block, parentAttrNames 
 			return fmt.Errorf(`parsing HCL expression %q: %s`, string(attrValLit), diags.Error())
 		}
 		aval, diags := dexpr.Value(&hcl.EvalContext{Functions: map[string]function.Function{
-			"jsondecode": stdlib.JSONDecodeFunc,
 			"jsonencode": stdlib.JSONEncodeFunc,
 		}})
 		if diags.HasErrors() {

--- a/tfadd/internal/tune_tpl.go
+++ b/tfadd/internal/tune_tpl.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/magodo/tfadd/schema"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
 
 	"github.com/zclconf/go-cty/cty/gocty"
 
@@ -80,7 +82,10 @@ func tuneForBlock(rb *hclwrite.Body, sch *tfpluginschema.Block, parentAttrNames 
 		if diags.HasErrors() {
 			return fmt.Errorf(`parsing HCL expression %q: %s`, string(attrValLit), diags.Error())
 		}
-		aval, diags := dexpr.Value(nil)
+		aval, diags := dexpr.Value(&hcl.EvalContext{Functions: map[string]function.Function{
+			"jsondecode": stdlib.JSONDecodeFunc,
+			"jsonencode": stdlib.JSONEncodeFunc,
+		}})
 		if diags.HasErrors() {
 			return fmt.Errorf(`evaluating value of HCL expression %q: %s`, string(attrValLit), diags.Error())
 		}


### PR DESCRIPTION
this PR will make the output of long json value more readable, which is important for generating azapi configuration.