### PR TITLE
Support azapi & `init` subcommand requires the long provider name (e.g. `hashicorp/azurerm`, `azure/azapi`)

### DIFF
--- a/.tools/schema-generator/azapi/main.go
+++ b/.tools/schema-generator/azapi/main.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/Azure/terraform-provider-azapi/internal/provider"
+	tfschema "github.com/magodo/tfadd/schema"
+	"github.com/magodo/tfpluginschema"
+)
+
+func main() {
+	schemas := map[string]*tfschema.Schema{}
+	for name, rs := range provider.AzureProvider().ResourcesMap {
+		schemas[name] = &tfschema.Schema{Block: tfpluginschema.FromSDKv2ProviderSchemaMap(rs.Schema)}
+	}
+	b, err := json.MarshalIndent(tfschema.ProviderSchema{ResourceSchemas: schemas}, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(string(b))
+}

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ Currently to generate the state, the tool supports *full mode* (with `-full`) or
 
     |Name|Version|
     |-|-|
-    |registry.terraform.io/hashicorp/aws|v4.67.0|
-    |registry.terraform.io/hashicorp/azurerm|v3.77.0|
-    |registry.terraform.io/hashicorp/google|v4.64.0|
+    |hashicorp/aws|v4.67.0|
+    |hashicorp/azurerm|v3.77.0|
+    |hashicorp/google|v4.64.0|
+    |azure/azapi|v1.9.0|
 
 ## Usage
 

--- a/providers/azapi/provider_gen.go
+++ b/providers/azapi/provider_gen.go
@@ -1,0 +1,324 @@
+// Auto-Generated Code; DO NOT EDIT.
+package azapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/magodo/tfadd/schema"
+	"os"
+)
+
+var ProviderSchemaInfo schema.ProviderSchema
+
+func init() {
+    b := []byte(`{
+  "Version": "",
+  "resource_schemas": {
+    "azapi_data_plane_resource": {
+      "block": {
+        "attributes": {
+          "body": {
+            "type": "string",
+            "optional": true,
+            "default": "{}"
+          },
+          "ignore_casing": {
+            "type": "bool",
+            "optional": true,
+            "default": false
+          },
+          "ignore_missing_property": {
+            "type": "bool",
+            "optional": true,
+            "default": true
+          },
+          "locks": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "name": {
+            "type": "string",
+            "required": true,
+            "force_new": true
+          },
+          "output": {
+            "type": "string",
+            "computed": true
+          },
+          "parent_id": {
+            "type": "string",
+            "required": true,
+            "force_new": true
+          },
+          "response_export_values": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "type": {
+            "type": "string",
+            "required": true
+          }
+        }
+      }
+    },
+    "azapi_resource": {
+      "block": {
+        "attributes": {
+          "body": {
+            "type": "string",
+            "optional": true,
+            "default": "{}"
+          },
+          "ignore_body_changes": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "ignore_casing": {
+            "type": "bool",
+            "optional": true,
+            "default": false
+          },
+          "ignore_missing_property": {
+            "type": "bool",
+            "optional": true,
+            "default": true
+          },
+          "location": {
+            "type": "string",
+            "optional": true,
+            "computed": true,
+            "force_new": true
+          },
+          "locks": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "name": {
+            "type": "string",
+            "optional": true,
+            "computed": true,
+            "force_new": true
+          },
+          "output": {
+            "type": "string",
+            "computed": true
+          },
+          "parent_id": {
+            "type": "string",
+            "optional": true,
+            "computed": true,
+            "force_new": true
+          },
+          "removing_special_chars": {
+            "type": "bool",
+            "optional": true,
+            "default": false
+          },
+          "response_export_values": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "schema_validation_enabled": {
+            "type": "bool",
+            "optional": true,
+            "default": true
+          },
+          "tags": {
+            "type": [
+              "map",
+              "string"
+            ],
+            "optional": true,
+            "computed": true
+          },
+          "type": {
+            "type": "string",
+            "required": true
+          }
+        },
+        "block_types": {
+          "identity": {
+            "nesting_mode": 3,
+            "block": {
+              "attributes": {
+                "identity_ids": {
+                  "type": [
+                    "list",
+                    "string"
+                  ],
+                  "optional": true
+                },
+                "principal_id": {
+                  "type": "string",
+                  "computed": true
+                },
+                "tenant_id": {
+                  "type": "string",
+                  "computed": true
+                },
+                "type": {
+                  "type": "string",
+                  "required": true
+                }
+              }
+            },
+            "optional": true,
+            "computed": true,
+            "max_items": 1
+          }
+        }
+      }
+    },
+    "azapi_resource_action": {
+      "block": {
+        "attributes": {
+          "action": {
+            "type": "string",
+            "optional": true,
+            "force_new": true
+          },
+          "body": {
+            "type": "string",
+            "optional": true
+          },
+          "locks": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "method": {
+            "type": "string",
+            "optional": true,
+            "default": "POST"
+          },
+          "output": {
+            "type": "string",
+            "computed": true
+          },
+          "resource_id": {
+            "type": "string",
+            "required": true,
+            "force_new": true
+          },
+          "response_export_values": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "type": {
+            "type": "string",
+            "required": true,
+            "force_new": true
+          }
+        }
+      }
+    },
+    "azapi_update_resource": {
+      "block": {
+        "attributes": {
+          "body": {
+            "type": "string",
+            "optional": true,
+            "default": "{}"
+          },
+          "ignore_body_changes": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "ignore_casing": {
+            "type": "bool",
+            "optional": true,
+            "default": false
+          },
+          "ignore_missing_property": {
+            "type": "bool",
+            "optional": true,
+            "default": true
+          },
+          "locks": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "name": {
+            "type": "string",
+            "optional": true,
+            "computed": true,
+            "force_new": true,
+            "exactly_one_of": [
+              "name",
+              "resource_id"
+            ],
+            "required_with": [
+              "parent_id"
+            ]
+          },
+          "output": {
+            "type": "string",
+            "computed": true
+          },
+          "parent_id": {
+            "type": "string",
+            "optional": true,
+            "computed": true,
+            "force_new": true,
+            "required_with": [
+              "name"
+            ]
+          },
+          "resource_id": {
+            "type": "string",
+            "optional": true,
+            "computed": true,
+            "force_new": true,
+            "exactly_one_of": [
+              "name",
+              "resource_id"
+            ]
+          },
+          "response_export_values": {
+            "type": [
+              "list",
+              "string"
+            ],
+            "optional": true
+          },
+          "type": {
+            "type": "string",
+            "required": true
+          }
+        }
+      }
+    }
+  }
+}`)
+	if err := json.Unmarshal(b, &ProviderSchemaInfo); err != nil {
+		fmt.Fprintf(os.Stderr, "unmarshalling the provider schema: %s", err)
+		os.Exit(1)
+	}
+    ProviderSchemaInfo.Version = "1.9.0"
+}

--- a/tfadd/providers.go
+++ b/tfadd/providers.go
@@ -2,13 +2,32 @@ package tfadd
 
 import (
 	"github.com/magodo/tfadd/providers/aws"
+	"github.com/magodo/tfadd/providers/azapi"
 	"github.com/magodo/tfadd/providers/azurerm"
 	"github.com/magodo/tfadd/providers/google"
 	"github.com/magodo/tfadd/schema"
 )
 
-var sdkProviderSchemas = map[string]schema.ProviderSchema{
-	"registry.terraform.io/hashicorp/azurerm": azurerm.ProviderSchemaInfo,
-	"registry.terraform.io/hashicorp/aws":     aws.ProviderSchemaInfo,
-	"registry.terraform.io/hashicorp/google":  google.ProviderSchemaInfo,
+type providerInfo struct {
+	FQName    string
+	SDKSchema schema.ProviderSchema
+}
+
+var supportedProviders = map[string]providerInfo{
+	"azure/azapi": {
+		FQName:    "registry.terraform.io/azure/azapi",
+		SDKSchema: azapi.ProviderSchemaInfo,
+	},
+	"hashicorp/azurerm": {
+		FQName:    "registry.terraform.io/hashicorp/azurerm",
+		SDKSchema: azurerm.ProviderSchemaInfo,
+	},
+	"hashicorp/aws": {
+		FQName:    "registry.terraform.io/hashicorp/aws",
+		SDKSchema: aws.ProviderSchemaInfo,
+	},
+	"hashicorp/google": {
+		FQName:    "registry.terraform.io/hashicorp/google",
+		SDKSchema: google.ProviderSchemaInfo,
+	},
 }

--- a/tfadd/tfadd_init.go
+++ b/tfadd/tfadd_init.go
@@ -3,6 +3,7 @@ package tfadd
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 )
 
@@ -19,14 +20,14 @@ func Init(providers []string) ([]byte, error) {
 
 	var infos []info
 	for _, p := range providers {
-		pinfo, ok := sdkProviderSchemas["registry.terraform.io/hashicorp/"+p]
+		pinfo, ok := supportedProviders[p]
 		if !ok {
 			return nil, fmt.Errorf("Unsupported provider %q\n", p)
 		}
 		infos = append(infos, info{
-			Name:    p,
-			Source:  "hashicorp/" + p,
-			Version: pinfo.Version,
+			Name:    strings.Split(p, "/")[1],
+			Source:  p,
+			Version: pinfo.SDKSchema.Version,
 		})
 	}
 
@@ -35,7 +36,7 @@ func Init(providers []string) ([]byte, error) {
   required_providers {
   {{- range . }}
     {{.Name}} = {
-      source = "hashicorp/{{.Name}}"
+      source = "{{.Source}}"
       version = "{{.Version}}"
     }
   {{- end }}

--- a/tfadd/tfadd_init_test.go
+++ b/tfadd/tfadd_init_test.go
@@ -21,7 +21,7 @@ func TestTFAdd_init(t *testing.T) {
 		},
 		{
 			name:      "azurerm provider only",
-			providers: []string{"azurerm"},
+			providers: []string{"hashicorp/azurerm"},
 			expect: regexp.MustCompile(`^terraform {
   required_providers {
     azurerm = {
@@ -33,8 +33,8 @@ func TestTFAdd_init(t *testing.T) {
 $`),
 		},
 		{
-			name:      "three providers only",
-			providers: []string{"azurerm", "google", "aws"},
+			name:      "four providers only",
+			providers: []string{"hashicorp/azurerm", "hashicorp/google", "hashicorp/aws", "azure/azapi"},
 			expect: regexp.MustCompile(`^terraform {
   required_providers {
     azurerm = {
@@ -47,6 +47,10 @@ $`),
     }
     aws = {
       source = "hashicorp/aws"
+      version = "\d+\.\d+\.\d+"
+    }
+    azapi = {
+      source = "azure/azapi"
       version = "\d+\.\d+\.\d+"
     }
   }

--- a/tfadd/tfadd_state.go
+++ b/tfadd/tfadd_state.go
@@ -3,6 +3,7 @@ package tfadd
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/magodo/tfadd/tfadd/internal"
 
@@ -166,10 +167,11 @@ func GenerateForOneResource(rsch *tfjson.Schema, res tfstate.StateResource, full
 		return nil, fmt.Errorf("generate template from state for %s: %v", res.Type, err)
 	}
 	if !full {
-		sdkPsch, ok := sdkProviderSchemas[res.ProviderName]
+		pinfo, ok := supportedProviders[strings.TrimPrefix(res.ProviderName, "registry.terraform.io/")]
 		if !ok {
 			return b, nil
 		}
+		sdkPsch := pinfo.SDKSchema
 		sch, ok := sdkPsch.ResourceSchemas[res.Type]
 		if !ok {
 			return b, nil

--- a/tfadd/tfadd_state_test.go
+++ b/tfadd/tfadd_state_test.go
@@ -162,7 +162,7 @@ resource "null_resource" "test" {
 
 			ctx := context.Background()
 			if os.Getenv(ENV_TFADD_DEV_PROVIDER) == "" {
-				b, err := Init([]string{"azurerm", "google", "aws"})
+				b, err := Init([]string{"hasicorp/azurerm", "hasicorp/google", "hasicorp/aws", "azure/azapi"})
 				require.NoError(t, err)
 				require.NoError(t, os.WriteFile(filepath.Join(wsp, "terraform.tf"), b, 0644))
 				require.NoError(t, tf.Init(ctx))

--- a/tfadd/tfadd_state_test.go
+++ b/tfadd/tfadd_state_test.go
@@ -162,7 +162,7 @@ resource "null_resource" "test" {
 
 			ctx := context.Background()
 			if os.Getenv(ENV_TFADD_DEV_PROVIDER) == "" {
-				b, err := Init([]string{"hasicorp/azurerm", "hasicorp/google", "hasicorp/aws", "azure/azapi"})
+				b, err := Init([]string{"hashicorp/azurerm", "hashicorp/google", "hashicorp/aws", "azure/azapi"})
 				require.NoError(t, err)
 				require.NoError(t, os.WriteFile(filepath.Join(wsp, "terraform.tf"), b, 0644))
 				require.NoError(t, tf.Init(ctx))


### PR DESCRIPTION
This PR add the `azure/azapi` as one of the awared providers.

Meanwhile, it introduces a breaking change on the `init` subcommand, where the provider name is now requiring its long form, e.g. `hashicorp/azurerm`, `azure/azapi`.