### PR TITLE
Special handling for azapi cfg tunning to keep O+C attrs/blks

### DIFF
--- a/tfadd/internal/tune_tpl.go
+++ b/tfadd/internal/tune_tpl.go
@@ -18,7 +18,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TuneTpl(sch schema.Schema, tpl []byte, rt string) ([]byte, error) {
+func TuneTpl(sch schema.Schema, tpl []byte, rt string, ocAttrsToKeep map[string]bool) ([]byte, error) {
 	f, diag := hclwrite.ParseConfig(tpl, "", hcl.InitialPos)
 	if diag.HasErrors() {
 		return nil, fmt.Errorf("parsing the generated template for %s: %s", rt, diag.Error())
@@ -28,13 +28,13 @@ func TuneTpl(sch schema.Schema, tpl []byte, rt string) ([]byte, error) {
 	rb.RemoveAttribute("id")
 	rb.RemoveBlock(rb.FirstMatchingBlock("timeouts", nil))
 
-	if err := tuneForBlock(rb, sch.Block, nil); err != nil {
+	if err := tuneForBlock(rb, sch.Block, nil, ocAttrsToKeep); err != nil {
 		return nil, err
 	}
 	return f.Bytes(), nil
 }
 
-func tuneForBlock(rb *hclwrite.Body, sch *tfpluginschema.Block, parentAttrNames []string) error {
+func tuneForBlock(rb *hclwrite.Body, sch *tfpluginschema.Block, parentAttrNames []string, ocAttrsToKeep map[string]bool) error {
 	for attrName, attrVal := range rb.Attributes() {
 		schAttr, ok := sch.Attributes[attrName]
 		if !ok {
@@ -62,9 +62,11 @@ func tuneForBlock(rb *hclwrite.Body, sch *tfpluginschema.Block, parentAttrNames 
 						continue
 					}
 				} else if len(schAttr.AtLeastOneOf) == 0 {
-					// For O+C attribute that has "AtLeastOneOf" constraint, keep it.
-					rb.RemoveAttribute(attrName)
-					continue
+					// For O+C attribute that has "AtLeastOneOf" constraint, or is explicitly specified, keep it.
+					if !(len(ocAttrsToKeep) != 0 && ocAttrsToKeep[attrName]) {
+						rb.RemoveAttribute(attrName)
+						continue
+					}
 				}
 			} else {
 				rb.RemoveAttribute(attrName)
@@ -73,22 +75,10 @@ func tuneForBlock(rb *hclwrite.Body, sch *tfpluginschema.Block, parentAttrNames 
 		}
 
 		// For optional only attributes, remove it from the output config if it either holds the default value or is null.
-		attrExpr, diags := hclwrite.ParseConfig(attrVal.BuildTokens(nil).Bytes(), "generate_attr", hcl.InitialPos)
-		if diags.HasErrors() {
-			return fmt.Errorf(`building attribute %q attribute: %s`, attrName, diags.Error())
+		aval, err := attrValue(attrName, attrVal)
+		if err != nil {
+			return err
 		}
-		attrValLit := attrExpr.Body().GetAttribute(attrName).Expr().BuildTokens(nil).Bytes()
-		dexpr, diags := hclsyntax.ParseExpression(attrValLit, "", hcl.InitialPos)
-		if diags.HasErrors() {
-			return fmt.Errorf(`parsing HCL expression %q: %s`, string(attrValLit), diags.Error())
-		}
-		aval, diags := dexpr.Value(&hcl.EvalContext{Functions: map[string]function.Function{
-			"jsonencode": stdlib.JSONEncodeFunc,
-		}})
-		if diags.HasErrors() {
-			return fmt.Errorf(`evaluating value of HCL expression %q: %s`, string(attrValLit), diags.Error())
-		}
-
 		if aval.IsNull() {
 			rb.RemoveAttribute(attrName)
 			continue
@@ -173,9 +163,28 @@ func tuneForBlock(rb *hclwrite.Body, sch *tfpluginschema.Block, parentAttrNames 
 			}
 		}
 
-		if err := tuneForBlock(blkVal.Body(), scht.Block, append(parentAttrNames, blkVal.Type())); err != nil {
+		if err := tuneForBlock(blkVal.Body(), scht.Block, append(parentAttrNames, blkVal.Type()), nil); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func attrValue(attrName string, attr *hclwrite.Attribute) (cty.Value, error) {
+	attrExpr, diags := hclwrite.ParseConfig(attr.BuildTokens(nil).Bytes(), "generate_attr", hcl.InitialPos)
+	if diags.HasErrors() {
+		return cty.Zero, fmt.Errorf(`building attribute %q attribute: %s`, attrName, diags.Error())
+	}
+	attrValLit := attrExpr.Body().GetAttribute(attrName).Expr().BuildTokens(nil).Bytes()
+	dexpr, diags := hclsyntax.ParseExpression(attrValLit, "", hcl.InitialPos)
+	if diags.HasErrors() {
+		return cty.Zero, fmt.Errorf(`parsing HCL expression %q: %s`, string(attrValLit), diags.Error())
+	}
+	aval, diags := dexpr.Value(&hcl.EvalContext{Functions: map[string]function.Function{
+		"jsonencode": stdlib.JSONEncodeFunc,
+	}})
+	if diags.HasErrors() {
+		return cty.Zero, fmt.Errorf(`evaluating value of HCL expression %q: %s`, string(attrValLit), diags.Error())
+	}
+	return aval, nil
 }

--- a/tfadd/tfadd_state.go
+++ b/tfadd/tfadd_state.go
@@ -182,6 +182,7 @@ func GenerateForOneResource(rsch *tfjson.Schema, res tfstate.StateResource, full
 				map[string]bool{
 					"name":      true,
 					"parent_id": true,
+					"identity":  true,
 					"location":  true,
 					"tags":      true,
 				},


### PR DESCRIPTION
By default, the tunning logic will remove non-`AtLeastOneOf` attributes/blocks, whilst many of the interesting properties in azapi are O+C, which will be skipped by default. This PR adds a new mechanism to allow explicitly keeping those interesting properties from being removed, as long as they are not null or equals to its default value.