### PR TITLE
New option: `-mask-sensitive` to allow masking sensitive attributes

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,6 +74,7 @@ Usage: tfadd [global options] state [options]
 Options:
 
   -full               Output all non-computed properties in the generated config
+  -mask-sensitive     Mask sensitive properties
   -target=addr        Only generate for the specified resource (can specify multiple times)
 `
 	return strings.TrimSpace(helpText)
@@ -82,6 +83,7 @@ Options:
 func (r *stateCommand) Run(args []string) int {
 	fset := defaultFlagSet("state")
 	flagFull := fset.Bool("full", false, "Whether to generate all non-computed properties")
+	flagMaskSensitive := fset.Bool("mask-sensitive", false, "Whether to mask sensitive properties")
 	var flagTargets arrayFlag
 	fset.Var(&flagTargets, "target", "Only generate for the specified resource")
 	if err := fset.Parse(args); err != nil {
@@ -103,7 +105,10 @@ func (r *stateCommand) Run(args []string) int {
 		fmt.Fprintf(os.Stderr, err.Error())
 		return 1
 	}
-	opts := []tfadd.StateOption{tfadd.Full(*flagFull)}
+	opts := []tfadd.OptionSetter{
+		tfadd.Full(*flagFull),
+		tfadd.MaskSenstitive(*flagMaskSensitive),
+	}
 
 	var template []byte
 	if len(flagTargets) == 0 {

--- a/tfadd/internal/option.go
+++ b/tfadd/internal/option.go
@@ -1,0 +1,7 @@
+package internal
+
+type Option struct {
+	// Whether to mask the sensitive attributes in the generated config?
+	// Set via MaskSensitive option.
+	MaskSensitive bool
+}

--- a/tfadd/internal/state_to_tpl.go
+++ b/tfadd/internal/state_to_tpl.go
@@ -17,25 +17,25 @@ import (
 )
 
 func ProviderTpl(name string, v cty.Value, schema *tfjson.SchemaBlock) ([]byte, error) {
-	var buf strings.Builder
-	buf.WriteString(fmt.Sprintf("provider %q {\n", name))
-	if err := addAttributes(&buf, v, schema.Attributes, 2); err != nil {
+	c := newConverter(nil, nil)
+	c.WriteString(fmt.Sprintf("provider %q {\n", name))
+	if err := c.AddAttributes(v, schema.Attributes, 2); err != nil {
 		return nil, err
 	}
-	if err := addBlocks(&buf, v, schema.NestedBlocks, 2); err != nil {
+	if err := c.AddBlocks(v, schema.NestedBlocks, 2); err != nil {
 		return nil, err
 	}
-	buf.WriteString("}\n")
-	return hclwrite.Format([]byte(buf.String())), nil
+	c.WriteString("}\n")
+	return hclwrite.Format([]byte(c.String())), nil
 }
 
-func StateToTpl(r *tfstate.StateResource, schema *tfjson.SchemaBlock) ([]byte, error) {
-	var buf strings.Builder
+func StateToTpl(r *tfstate.StateResource, schema *tfjson.SchemaBlock, opt *Option) ([]byte, error) {
+	c := newConverter(nil, opt)
 	addr, err := addr2.ParseResourceAddr(r.Address)
 	if err != nil {
 		return nil, fmt.Errorf("parsing resource address: %v", err)
 	}
-	buf.WriteString(fmt.Sprintf("resource %q %q {\n", addr.Type, addr.Name))
+	c.WriteString(fmt.Sprintf("resource %q %q {\n", addr.Type, addr.Name))
 
 	// Special handling on attribute "id" to make it a Computed only attribute. This is mainly for the provider that is using the plugin sdk v2, where it is set to be O+C.
 	schema.Attributes["id"] = &tfjson.SchemaAttribute{
@@ -43,31 +43,44 @@ func StateToTpl(r *tfstate.StateResource, schema *tfjson.SchemaBlock) ([]byte, e
 		Computed:      true,
 	}
 
-	if err := addAttributes(&buf, r.Value, schema.Attributes, 2); err != nil {
+	if err := c.AddAttributes(r.Value, schema.Attributes, 2); err != nil {
 		return nil, err
 	}
-	if err := addBlocks(&buf, r.Value, schema.NestedBlocks, 2); err != nil {
+	if err := c.AddBlocks(r.Value, schema.NestedBlocks, 2); err != nil {
 		return nil, err
 	}
-	addDependency(&buf, r.DependsOn, 2)
-	buf.WriteString("}\n")
-	return hclwrite.Format([]byte(buf.String())), nil
+	c.AddDependency(r.DependsOn, 2)
+	c.WriteString("}\n")
+	return hclwrite.Format([]byte(c.String())), nil
 }
 
-func addDependency(buf *strings.Builder, deps []string, indent int) {
-	if len(deps) == 0 {
-		return
-	}
-	buf.WriteString(strings.Repeat(" ", indent))
-	buf.WriteString("depends_on = [\n")
-	for _, dep := range deps {
-		buf.WriteString(strings.Repeat(" ", indent+2) + dep + ",\n")
-	}
-	buf.WriteString(strings.Repeat(" ", indent))
-	buf.WriteString("]\n")
+type converter struct {
+	buf *strings.Builder
+	opt Option
 }
 
-func addAttributes(buf *strings.Builder, stateVal cty.Value, attrs map[string]*tfjson.SchemaAttribute, indent int) error {
+func newConverter(buf *strings.Builder, opt *Option) converter {
+	if buf == nil {
+		buf = &strings.Builder{}
+	}
+	if opt == nil {
+		opt = &Option{}
+	}
+	return converter{
+		buf: buf,
+		opt: *opt,
+	}
+}
+
+func (c converter) WriteString(s string) (int, error) {
+	return c.buf.WriteString(s)
+}
+
+func (c converter) String() string {
+	return c.buf.String()
+}
+
+func (c converter) AddAttributes(stateVal cty.Value, attrs map[string]*tfjson.SchemaAttribute, indent int) error {
 	if len(attrs) == 0 || stateVal.IsNull() {
 		return nil
 	}
@@ -81,6 +94,15 @@ func addAttributes(buf *strings.Builder, stateVal cty.Value, attrs map[string]*t
 	for i := range keys {
 		name := keys[i]
 		attrS := attrs[name]
+
+		// Optionally mask sensitive attributes
+		if c.opt.MaskSensitive && attrS.Sensitive {
+			if err := c.AddMaskedAttr(name, attrS, indent); err != nil {
+				return err
+			}
+			continue
+		}
+
 		if attrS.AttributeNestedType != nil {
 			// This shouldn't happen in real usage; state always has all values (set
 			// to null as needed), but it protects against panics in tests (and any
@@ -89,7 +111,7 @@ func addAttributes(buf *strings.Builder, stateVal cty.Value, attrs map[string]*t
 				continue
 			}
 			nestedVal := stateVal.GetAttr(name)
-			if err := addAttributeNestedTypeAttributes(buf, name, attrS, nestedVal, indent); err != nil {
+			if err := c.AddAttributeNestedTypeAttributes(name, attrS, nestedVal, indent); err != nil {
 				return err
 			}
 			continue
@@ -111,8 +133,8 @@ func addAttributes(buf *strings.Builder, stateVal cty.Value, attrs map[string]*t
 				continue
 			}
 
-			buf.WriteString(strings.Repeat(" ", indent))
-			buf.WriteString(fmt.Sprintf("%s = ", name))
+			c.buf.WriteString(strings.Repeat(" ", indent))
+			c.buf.WriteString(fmt.Sprintf("%s = ", name))
 			tok := hclwrite.TokensForValue(val)
 			// use jsonencode if val is valid json object
 			bs := tok.Bytes()
@@ -126,50 +148,63 @@ func addAttributes(buf *strings.Builder, stateVal cty.Value, attrs map[string]*t
 					}
 				}
 			}
-			buf.Write(bs)
+			c.buf.Write(bs)
 
-			buf.WriteString("\n")
+			c.buf.WriteString("\n")
 		}
 	}
 	return nil
 }
 
-func addAttributeNestedTypeAttributes(buf *strings.Builder, name string, schema *tfjson.SchemaAttribute, stateVal cty.Value, indent int) error {
+func (c converter) AddDependency(deps []string, indent int) {
+	if len(deps) == 0 {
+		return
+	}
+	c.buf.WriteString(strings.Repeat(" ", indent))
+	c.buf.WriteString("depends_on = [\n")
+	for _, dep := range deps {
+		c.buf.WriteString(strings.Repeat(" ", indent+2) + dep + ",\n")
+	}
+	c.buf.WriteString(strings.Repeat(" ", indent))
+	c.buf.WriteString("]\n")
+}
+
+func (c converter) AddAttributeNestedTypeAttributes(name string, schema *tfjson.SchemaAttribute, stateVal cty.Value, indent int) error {
 	if stateVal.IsNull() {
 		return nil
 	}
-	buf.WriteString(strings.Repeat(" ", indent))
-	buf.WriteString(fmt.Sprintf("%s = ", name))
+	c.buf.WriteString(strings.Repeat(" ", indent))
+	c.buf.WriteString(fmt.Sprintf("%s = ", name))
 	switch schema.AttributeNestedType.NestingMode {
 	case tfjson.SchemaNestingModeSingle:
-		buf.WriteString("{\n")
+		c.buf.WriteString("{\n")
 
-		if err := addAttributes(buf, stateVal, schema.AttributeNestedType.Attributes, indent+2); err != nil {
+		if err := c.AddAttributes(stateVal, schema.AttributeNestedType.Attributes, indent+2); err != nil {
 			return err
 		}
-		buf.WriteString("}\n")
+		c.buf.WriteString("}\n")
 		return nil
 
 	case tfjson.SchemaNestingModeList, tfjson.SchemaNestingModeSet:
-		buf.WriteString("[\n")
+		c.buf.WriteString("[\n")
 
 		listVals := ctyCollectionValues(stateVal)
 		for i := range listVals {
-			buf.WriteString(strings.Repeat(" ", indent+2))
+			c.buf.WriteString(strings.Repeat(" ", indent+2))
 
-			buf.WriteString("{\n")
-			if err := addAttributes(buf, listVals[i], schema.AttributeNestedType.Attributes, indent+4); err != nil {
+			c.buf.WriteString("{\n")
+			if err := c.AddAttributes(listVals[i], schema.AttributeNestedType.Attributes, indent+4); err != nil {
 				return err
 			}
-			buf.WriteString(strings.Repeat(" ", indent+2))
-			buf.WriteString("},\n")
+			c.buf.WriteString(strings.Repeat(" ", indent+2))
+			c.buf.WriteString("},\n")
 		}
-		buf.WriteString(strings.Repeat(" ", indent))
-		buf.WriteString("]\n")
+		c.buf.WriteString(strings.Repeat(" ", indent))
+		c.buf.WriteString("]\n")
 		return nil
 
 	case tfjson.SchemaNestingModeMap:
-		buf.WriteString("{\n")
+		c.buf.WriteString("{\n")
 
 		vals := stateVal.AsValueMap()
 		keys := make([]string, 0, len(vals))
@@ -178,18 +213,18 @@ func addAttributeNestedTypeAttributes(buf *strings.Builder, name string, schema 
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
-			buf.WriteString(strings.Repeat(" ", indent+2))
-			buf.WriteString(fmt.Sprintf("%s = {", key))
+			c.buf.WriteString(strings.Repeat(" ", indent+2))
+			c.buf.WriteString(fmt.Sprintf("%s = {", key))
 
-			buf.WriteString("\n")
-			if err := addAttributes(buf, vals[key], schema.AttributeNestedType.Attributes, indent+4); err != nil {
+			c.buf.WriteString("\n")
+			if err := c.AddAttributes(vals[key], schema.AttributeNestedType.Attributes, indent+4); err != nil {
 				return err
 			}
-			buf.WriteString(strings.Repeat(" ", indent+2))
-			buf.WriteString("}\n")
+			c.buf.WriteString(strings.Repeat(" ", indent+2))
+			c.buf.WriteString("}\n")
 		}
-		buf.WriteString(strings.Repeat(" ", indent))
-		buf.WriteString("}\n")
+		c.buf.WriteString(strings.Repeat(" ", indent))
+		c.buf.WriteString("}\n")
 		return nil
 
 	default:
@@ -198,7 +233,7 @@ func addAttributeNestedTypeAttributes(buf *strings.Builder, name string, schema 
 	}
 }
 
-func addBlocks(buf *strings.Builder, stateVal cty.Value, blocks map[string]*tfjson.SchemaBlockType, indent int) error {
+func (c converter) AddBlocks(stateVal cty.Value, blocks map[string]*tfjson.SchemaBlockType, indent int) error {
 	if len(blocks) == 0 || stateVal.IsNull() {
 		return nil
 	}
@@ -218,7 +253,7 @@ func addBlocks(buf *strings.Builder, stateVal cty.Value, blocks map[string]*tfjs
 			continue
 		}
 		blockVal := stateVal.GetAttr(name)
-		if err := addNestedBlock(buf, name, blockS, blockVal, indent); err != nil {
+		if err := c.AddNestedBlock(name, blockS, blockVal, indent); err != nil {
 			return err
 		}
 	}
@@ -226,7 +261,7 @@ func addBlocks(buf *strings.Builder, stateVal cty.Value, blocks map[string]*tfjs
 	return nil
 }
 
-func addNestedBlock(buf *strings.Builder, name string, schema *tfjson.SchemaBlockType, stateVal cty.Value, indent int) error {
+func (c converter) AddNestedBlock(name string, schema *tfjson.SchemaBlockType, stateVal cty.Value, indent int) error {
 	if stateVal.IsNull() {
 		return nil
 	}
@@ -240,30 +275,30 @@ func addNestedBlock(buf *strings.Builder, name string, schema *tfjson.SchemaBloc
 
 	switch schema.NestingMode {
 	case tfjson.SchemaNestingModeSingle, tfjson.SchemaNestingModeGroup:
-		buf.WriteString(strings.Repeat(" ", indent))
-		buf.WriteString(fmt.Sprintf("%s {", name))
+		c.buf.WriteString(strings.Repeat(" ", indent))
+		c.buf.WriteString(fmt.Sprintf("%s {", name))
 
-		buf.WriteString("\n")
-		if err := addAttributes(buf, stateVal, schema.Block.Attributes, indent+2); err != nil {
+		c.buf.WriteString("\n")
+		if err := c.AddAttributes(stateVal, schema.Block.Attributes, indent+2); err != nil {
 			return err
 		}
-		if err := addBlocks(buf, stateVal, schema.Block.NestedBlocks, indent+2); err != nil {
+		if err := c.AddBlocks(stateVal, schema.Block.NestedBlocks, indent+2); err != nil {
 			return err
 		}
-		buf.WriteString("}\n")
+		c.buf.WriteString("}\n")
 		return nil
 	case tfjson.SchemaNestingModeList, tfjson.SchemaNestingModeSet:
 		listVals := ctyCollectionValues(stateVal)
 		for i := range listVals {
-			buf.WriteString(strings.Repeat(" ", indent))
-			buf.WriteString(fmt.Sprintf("%s {\n", name))
-			if err := addAttributes(buf, listVals[i], schema.Block.Attributes, indent+2); err != nil {
+			c.buf.WriteString(strings.Repeat(" ", indent))
+			c.buf.WriteString(fmt.Sprintf("%s {\n", name))
+			if err := c.AddAttributes(listVals[i], schema.Block.Attributes, indent+2); err != nil {
 				return err
 			}
-			if err := addBlocks(buf, listVals[i], schema.Block.NestedBlocks, indent+2); err != nil {
+			if err := c.AddBlocks(listVals[i], schema.Block.NestedBlocks, indent+2); err != nil {
 				return err
 			}
-			buf.WriteString("}\n")
+			c.buf.WriteString("}\n")
 		}
 		return nil
 	case tfjson.SchemaNestingModeMap:
@@ -274,24 +309,62 @@ func addNestedBlock(buf *strings.Builder, name string, schema *tfjson.SchemaBloc
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
-			buf.WriteString(strings.Repeat(" ", indent))
-			buf.WriteString(fmt.Sprintf("%s %q {", name, key))
-			buf.WriteString("\n")
+			c.buf.WriteString(strings.Repeat(" ", indent))
+			c.buf.WriteString(fmt.Sprintf("%s %q {", name, key))
+			c.buf.WriteString("\n")
 
-			if err := addAttributes(buf, vals[key], schema.Block.Attributes, indent+2); err != nil {
+			if err := c.AddAttributes(vals[key], schema.Block.Attributes, indent+2); err != nil {
 				return err
 			}
-			if err := addBlocks(buf, vals[key], schema.Block.NestedBlocks, indent+2); err != nil {
+			if err := c.AddBlocks(vals[key], schema.Block.NestedBlocks, indent+2); err != nil {
 				return err
 			}
-			buf.WriteString(strings.Repeat(" ", indent))
-			buf.WriteString("}\n")
+			c.buf.WriteString(strings.Repeat(" ", indent))
+			c.buf.WriteString("}\n")
 		}
 		return nil
 	default:
 		// This should not happen, the above should be exhaustive.
 		return fmt.Errorf("unsupported NestingMode %s", schema.NestingMode)
 	}
+}
+
+func (c converter) AddMaskedAttr(name string, schema *tfjson.SchemaAttribute, indent int) error {
+	var v string
+	if schema.AttributeNestedType != nil {
+		switch schema.AttributeNestedType.NestingMode {
+		case tfjson.SchemaNestingModeSingle, tfjson.SchemaNestingModeMap:
+			v = "{}"
+		case tfjson.SchemaNestingModeList, tfjson.SchemaNestingModeSet:
+			v = "[]"
+		default:
+			// This should not happen, the above should be exhaustive.
+			return fmt.Errorf("unsupported NestingMode %s", schema.AttributeNestedType.NestingMode)
+		}
+	} else {
+		switch schema.AttributeType {
+		case cty.Number:
+			v = "0"
+		case cty.Bool:
+			v = "false"
+		case cty.String:
+			v = `""`
+		default:
+			switch {
+			case schema.AttributeType.IsListType():
+				v = "[]"
+			case schema.AttributeType.IsSetType():
+				v = "[]"
+			case schema.AttributeType.IsMapType():
+				v = "{}"
+			default:
+				return fmt.Errorf("unhandled attribute type: %s", schema.AttributeType.FriendlyName())
+			}
+		}
+	}
+	c.buf.WriteString(strings.Repeat(" ", indent))
+	c.buf.WriteString(fmt.Sprintf("%s = %s # Masked sensitive attribute\n", name, v))
+	return nil
 }
 
 func ctyCollectionValues(val cty.Value) []cty.Value {

--- a/tfadd/option.go
+++ b/tfadd/option.go
@@ -1,10 +1,20 @@
 package tfadd
 
-type StateOption interface {
-	configureState(*stateConfig)
+type Option struct {
+	// Whether the generated config contains all the non-computed properties?
+	// Set via Full option.
+	full bool
+
+	// Whether to mask the sensitive attributes in the generated config?
+	// Set via MaskSensitive option.
+	maskSensitive bool
 }
 
-var _ StateOption = fullOption(true)
+type OptionSetter interface {
+	configureState(*Option)
+}
+
+var _ OptionSetter = fullOption(true)
 
 type fullOption bool
 
@@ -12,6 +22,18 @@ func Full(b bool) fullOption {
 	return fullOption(b)
 }
 
-func (opt fullOption) configureState(cfg *stateConfig) {
+func (opt fullOption) configureState(cfg *Option) {
 	cfg.full = bool(opt)
+}
+
+var _ OptionSetter = maskSensitiveOption(true)
+
+type maskSensitiveOption bool
+
+func MaskSenstitive(b bool) maskSensitiveOption {
+	return maskSensitiveOption(b)
+}
+
+func (opt maskSensitiveOption) configureState(cfg *Option) {
+	cfg.maskSensitive = bool(opt)
 }

--- a/tfadd/tfadd_state_test.go
+++ b/tfadd/tfadd_state_test.go
@@ -55,7 +55,7 @@ func TestTFAdd_resource(t *testing.T) {
 	cases := []struct {
 		name        string
 		statefile   string
-		options     []StateOption
+		options     []OptionSetter
 		targets     []string
 		expectError *regexp.Regexp
 		expect      string
@@ -80,7 +80,7 @@ resource "azurerm_resource_group" "b" {
 		{
 			name:      "generate all supported resources in the state, full",
 			statefile: "azurerm_resource_groups",
-			options:   []StateOption{Full(true)},
+			options:   []OptionSetter{Full(true)},
 			expect: `resource "azurerm_resource_group" "a" {
   location = "eastus2"
   name     = "foo"


### PR DESCRIPTION
This PR adds new option `-mask-sensitive` to allow masking sensitive attributes. The masking is done by generating the zero value of that attribute, with a comment stating the reason. In non-full mode, those value will be trimed from the configuration, as they are of the zero values. While in the full mode, they are kept with the zero value + comments.

Meanwhile, this PR made some adjustment to some public functions, to make the structure more clear.