### PR TITLE
Config tune: split trim mode into combinable `-keep-*` flags

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,10 +19,9 @@ jobs:
         go-version: 1.23.0
 
     - name: Set up Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@v4
       with:
-        terraform_version: 1.11.4
-        terraform_wrapper: false
+        terraform_version: 1.14.6
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,12 @@ jobs:
       with:
         go-version: 1.23.0
 
+    - name: Set up Terraform
+      uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: 1.11.4
+        terraform_wrapper: false
+
     - name: Build
       run: go build -v ./...
 

--- a/main.go
+++ b/main.go
@@ -71,9 +71,17 @@ Usage: tfadd [global options] state [options]
 
   Generates resource template from Terraform state to standard output.
 
+  By default, several categories of attributes/blocks are trimmed from the
+  generated config
+
 Options:
 
-  -full               Output all non-computed properties in the generated config
+  -full               Shorthand for "-keep-oc -keep-zero -keep-default".
+  -keep-oc            Keep Optional+Computed (O+C) attributes/blocks
+  -keep-zero          Keep Optional attributes whose value equals the type's
+                      zero value (when no schema default is defined)
+  -keep-default       Keep Optional attributes whose value equals the
+                      schema-defined default
   -mask-sensitive     Mask sensitive properties
   -target=addr        Only generate for the specified resource (can specify multiple times)
   -chdir              Change the current working directory
@@ -83,7 +91,10 @@ Options:
 
 func (r *stateCommand) Run(args []string) int {
 	fset := defaultFlagSet("state")
-	flagFull := fset.Bool("full", false, "Whether to generate all non-computed properties")
+	flagFull := fset.Bool("full", false, "Shorthand for -keep-oc -keep-zero -keep-default")
+	flagKeepOC := fset.Bool("keep-oc", false, "Keep Optional+Computed (O+C) attributes/blocks")
+	flagKeepZero := fset.Bool("keep-zero", false, "Keep Optional attributes equal to the type's zero value")
+	flagKeepDefault := fset.Bool("keep-default", false, "Keep Optional attributes equal to the schema-defined default")
 	flagChdir := fset.String("chdir", ".", "Change the current working directory")
 	flagMaskSensitive := fset.Bool("mask-sensitive", false, "Whether to mask sensitive properties")
 	var flagTargets arrayFlag
@@ -109,6 +120,9 @@ func (r *stateCommand) Run(args []string) int {
 	}
 	opts := []tfadd.OptionSetter{
 		tfadd.Full(*flagFull),
+		tfadd.KeepOC(*flagKeepOC),
+		tfadd.KeepZero(*flagKeepZero),
+		tfadd.KeepDefault(*flagKeepDefault),
 		tfadd.MaskSenstitive(*flagMaskSensitive),
 	}
 

--- a/tfadd/internal/option.go
+++ b/tfadd/internal/option.go
@@ -17,7 +17,6 @@ type TuneOption struct {
 	OCToKeep map[string]bool
 
 	// Whether to remove optional attributes whose value equals the type's zero value (used when the schema does not define a default).
-	// A null attribute value also counts as zero and is removed when this is enabled.
 	RemoveOZeroAttribute bool
 
 	// Whether to remove optional attributes whose value equals the schema-defined default value.

--- a/tfadd/internal/option.go
+++ b/tfadd/internal/option.go
@@ -16,6 +16,10 @@ type TuneOption struct {
 	// For block, the address is separated by ".0.".
 	OCToKeep map[string]bool
 
-	// Whether to remove optional attributes, whose value equals to its default value or zero value (default not defined)
-	RemoveOZAttribute bool
+	// Whether to remove optional attributes whose value equals the type's zero value (used when the schema does not define a default).
+	// A null attribute value also counts as zero and is removed when this is enabled.
+	RemoveOZeroAttribute bool
+
+	// Whether to remove optional attributes whose value equals the schema-defined default value.
+	RemoveODefaultAttribute bool
 }

--- a/tfadd/internal/tune_tpl.go
+++ b/tfadd/internal/tune_tpl.go
@@ -123,14 +123,31 @@ func (t trimmer) tuneAttributes(parentAddr Addr, rb *hclwrite.Body, attrSchs tfp
 			}
 		}
 
-		// Removing Optional "zero" valued attribute
-		if t.Option.RemoveOZAttribute {
-			if sch.NestedType == nil && sch.Optional {
-				ok, err := t.attributeIsDefaultOrZeroValue(attrName, attrVal, sch)
+		// Optional only primitive types
+		if sch.Optional && sch.NestedType == nil {
+			// Removing Optional attribute whose value equals to its zero value
+			if sch.Default == nil && t.Option.RemoveOZeroAttribute {
+				aval, err := t.attrCty(attrName, attrVal, sch)
 				if err != nil {
-					return addr.NewErrorf("checking attribute value is default or zero: %v", err)
+					return addr.NewErrorf("parsing attribute value: %v", err)
 				}
-				if ok {
+				if attributeIsZeroValue(aval, sch) {
+					t.removeAttribute(rb, addr, attrName)
+					continue
+				}
+			}
+
+			// Removing Optional attribute whose value equals the schema-defined default.
+			if t.Option.RemoveODefaultAttribute {
+				aval, err := t.attrCty(attrName, attrVal, sch)
+				if err != nil {
+					return addr.NewErrorf("parsing attribute value: %v", err)
+				}
+				isDefault, err := attributeIsDefaultValue(aval, sch)
+				if err != nil {
+					return addr.NewErrorf("checking attribute equals schema default: %v", err)
+				}
+				if isDefault {
 					t.removeAttribute(rb, addr, attrName)
 					continue
 				}
@@ -191,69 +208,96 @@ func (t trimmer) tuneBlock(rb *hclwrite.Body, sch *tfpluginschema.SchemaBlock, p
 	return nil
 }
 
-// attributeIsDefaultOrZeroValue returns if the attribute is null, or equals to either its default value (defined in schema), or (default value undefined) zero value.
-func (t trimmer) attributeIsDefaultOrZeroValue(attrName string, attrVal *hclwrite.Attribute, attrSch *tfpluginschema.SchemaAttribute) (bool, error) {
+// attrCty parses the attribute value and, for collection types, normalizes
+// HCL tuple/object literals (e.g. `[]`, `{}`) into properly typed List/Set/Map
+// values so that they can be compared with their schema-defined defaults or
+// type zero values.
+func (t trimmer) attrCty(attrName string, attrVal *hclwrite.Attribute, attrSch *tfpluginschema.SchemaAttribute) (cty.Value, error) {
 	if attrSch.NestedType != nil {
 		panic("attributes of nested object are not supported")
 	}
 	aval, err := t.attrValue(attrName, attrVal)
 	if err != nil {
-		return false, err
+		return cty.NilVal, err
 	}
-	if aval.IsNull() {
-		return true, nil
+	if aval.IsNull() || attrSch.Type == nil {
+		return aval, nil
 	}
+	ty := *attrSch.Type
+	switch {
+	case ty.IsListType():
+		if len(aval.AsValueSlice()) == 0 {
+			return cty.ListValEmpty(ty.ElementType()), nil
+		}
+		return cty.ListVal(aval.AsValueSlice()), nil
+	case ty.IsSetType():
+		if len(aval.AsValueSlice()) == 0 {
+			return cty.SetValEmpty(ty.ElementType()), nil
+		}
+		return cty.SetVal(aval.AsValueSlice()), nil
+	case ty.IsMapType():
+		if len(aval.AsValueMap()) == 0 {
+			return cty.MapValEmpty(ty.ElementType()), nil
+		}
+		return cty.MapVal(aval.AsValueMap()), nil
+	}
+	return aval, nil
+}
 
-	// Non null attribute, continue checking whether it equals to the default value.
+// attributeIsZeroValue reports whether the given (parsed and normalized)
+// attribute value is the "zero" value for an Optional attribute.
+// Note that null is not a zero value.
+func attributeIsZeroValue(aval cty.Value, attrSch *tfpluginschema.SchemaAttribute) bool {
 	var dval cty.Value
+	if attrSch.Type == nil {
+		return false
+	}
 
-	if attrSch.Type != nil {
-		switch *attrSch.Type {
-		case cty.Number:
-			dval = cty.Zero
-		case cty.Bool:
-			dval = cty.False
-		case cty.String:
-			dval = cty.StringVal("")
-		default:
-			if attrSch.Type.IsListType() {
-				dval = cty.ListValEmpty(attrSch.Type.ElementType())
-				if len(aval.AsValueSlice()) == 0 {
-					aval = dval
-				} else {
-					aval = cty.ListVal(aval.AsValueSlice())
-				}
-				break
-			}
-			if attrSch.Type.IsSetType() {
-				dval = cty.SetValEmpty(attrSch.Type.ElementType())
-				if len(aval.AsValueSlice()) == 0 {
-					aval = dval
-				} else {
-					aval = cty.SetVal(aval.AsValueSlice())
-				}
-				break
-			}
-			if attrSch.Type.IsMapType() {
-				dval = cty.MapValEmpty(attrSch.Type.ElementType())
-				if len(aval.AsValueMap()) == 0 {
-					aval = dval
-				} else {
-					aval = cty.MapVal(aval.AsValueMap())
-				}
-				break
-			}
+	ty := *attrSch.Type
+
+	switch ty {
+	case cty.Number:
+		dval = cty.Zero
+	case cty.Bool:
+		dval = cty.False
+	case cty.String:
+		dval = cty.StringVal("")
+	default:
+		switch {
+		case ty.IsListType():
+			dval = cty.ListValEmpty(ty.ElementType())
+		case ty.IsSetType():
+			dval = cty.SetValEmpty(ty.ElementType())
+		case ty.IsMapType():
+			dval = cty.MapValEmpty(ty.ElementType())
 		}
 	}
 
-	if attrSch.Default != nil && attrSch.Type != nil {
-		var err error
-		dval, err = gocty.ToCtyValue(attrSch.Default, *attrSch.Type)
-		if err != nil {
-			return false, fmt.Errorf("converting cty value %v to Go: %v", attrSch.Default, err)
-		}
+	if dval.IsNull() {
+		return false
 	}
 
+	return aval.Equals(dval).True()
+}
+
+// attributeIsDefaultValue reports whether the given (parsed and normalized)
+// attribute value equals the schema-defined default value.
+// Note that null is the "default" default value when no default is defined.
+func attributeIsDefaultValue(aval cty.Value, attrSch *tfpluginschema.SchemaAttribute) (bool, error) {
+	if attrSch.Default == nil {
+		if aval.IsNull() {
+			return true, nil
+		} else {
+			return false, nil
+		}
+	}
+	if attrSch.Type == nil {
+		return false, nil
+	}
+	dval, err := gocty.ToCtyValue(attrSch.Default, *attrSch.Type)
+	if err != nil {
+		return false, fmt.Errorf("converting default value %v: %v", attrSch.Default, err)
+	}
 	return aval.Equals(dval).True(), nil
 }
 

--- a/tfadd/internal/tune_tpl_test.go
+++ b/tfadd/internal/tune_tpl_test.go
@@ -35,12 +35,12 @@ func TestTuneTpl(t *testing.T) {
 	expect := `resource "foo" "test" {
   req {}
 }`
-	actual, err := TuneTpl(sch, []byte(input), &TuneOption{RemoveOC: true, RemoveOZAttribute: true})
+	actual, err := TuneTpl(sch, []byte(input), &TuneOption{RemoveOC: true, RemoveOZeroAttribute: true, RemoveODefaultAttribute: true})
 	require.NoError(t, err)
 	require.Equal(t, expect, string(actual))
 }
 
-func TestTuneForBlock(t *testing.T) {
+func TestTuneForBlock_removeAll(t *testing.T) {
 	cases := []struct {
 		name   string
 		schema tfpluginschema.SchemaBlock
@@ -87,7 +87,7 @@ func TestTuneForBlock(t *testing.T) {
 }`,
 		},
 		{
-			name: "optional attributes with default value",
+			name: "optional attributes with zero value",
 			schema: tfpluginschema.SchemaBlock{
 				Attributes: []*tfpluginschema.SchemaAttribute{
 					{
@@ -560,7 +560,7 @@ func TestTuneForBlock(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			actual, err := TuneTpl(schema.Schema{Block: &c.schema}, []byte(c.input), &TuneOption{RemoveOC: true, RemoveOZAttribute: true, OCToKeep: c.ocKeep})
+			actual, err := TuneTpl(schema.Schema{Block: &c.schema}, []byte(c.input), &TuneOption{RemoveOC: true, RemoveOZeroAttribute: true, RemoveODefaultAttribute: true, OCToKeep: c.ocKeep})
 			require.NoError(t, err)
 			require.Equal(t, c.expect, string(actual))
 		})
@@ -569,4 +569,292 @@ func TestTuneForBlock(t *testing.T) {
 
 func ToPtr[T any](v T) *T {
 	return &v
+}
+
+func TestTuneForBlock_PerKeepOption(t *testing.T) {
+	mixedSchema := tfpluginschema.SchemaBlock{
+		Attributes: []*tfpluginschema.SchemaAttribute{
+			{Name: "oc", Type: ToPtr(cty.Number), Optional: true, Computed: true},
+			{Name: "opt_zero", Type: ToPtr(cty.Number), Optional: true},
+			{Name: "opt_nonzero", Type: ToPtr(cty.Number), Optional: true},
+			{Name: "opt_default", Type: ToPtr(cty.Number), Optional: true, Default: 5},
+			{Name: "opt_nondef", Type: ToPtr(cty.Number), Optional: true, Default: 5},
+		},
+	}
+	mixedInput := `resource "foo" "test" {
+  oc          = 1
+  opt_zero    = 0
+  opt_nonzero = 2
+  opt_default = 5
+  opt_nondef  = 7
+}`
+
+	cases := []struct {
+		name   string
+		option TuneOption
+		schema tfpluginschema.SchemaBlock
+		input  string
+		expect string
+	}{
+		{
+			name:   "all flags off keeps everything except C-only",
+			option: TuneOption{},
+			schema: tfpluginschema.SchemaBlock{
+				Attributes: []*tfpluginschema.SchemaAttribute{
+					{Name: "oc", Type: ToPtr(cty.Number), Optional: true, Computed: true},
+					{Name: "comp", Type: ToPtr(cty.Number), Computed: true},
+					{Name: "opt_zero", Type: ToPtr(cty.Number), Optional: true},
+					{Name: "opt_default", Type: ToPtr(cty.Number), Optional: true, Default: 5},
+				},
+			},
+			input: `resource "foo" "test" {
+  oc          = 1
+  comp        = 2
+  opt_zero    = 0
+  opt_default = 5
+}`,
+			expect: `resource "foo" "test" {
+  oc          = 1
+  opt_zero    = 0
+  opt_default = 5
+}`,
+		},
+
+		// ---- RemoveOC only ----
+		{
+			name:   "RemoveOC only removes O+C and keeps zero/default values",
+			option: TuneOption{RemoveOC: true},
+			schema: mixedSchema,
+			input:  mixedInput,
+			expect: `resource "foo" "test" {
+  opt_zero    = 0
+  opt_nonzero = 2
+  opt_default = 5
+  opt_nondef  = 7
+}`,
+		},
+		{
+			name:   "RemoveOC only honors OCToKeep override",
+			option: TuneOption{RemoveOC: true, OCToKeep: map[string]bool{"oc": true}},
+			schema: tfpluginschema.SchemaBlock{
+				Attributes: []*tfpluginschema.SchemaAttribute{
+					{Name: "oc", Type: ToPtr(cty.Number), Optional: true, Computed: true},
+					{Name: "oc2", Type: ToPtr(cty.Number), Optional: true, Computed: true},
+				},
+			},
+			input: `resource "foo" "test" {
+  oc  = 1
+  oc2 = 2
+}`,
+			expect: `resource "foo" "test" {
+  oc = 1
+}`,
+		},
+
+		// ---- RemoveOZeroAttribute only ----
+		{
+			name:   "RemoveOZeroAttribute only removes zero-valued O and keeps O+C/default",
+			option: TuneOption{RemoveOZeroAttribute: true},
+			schema: mixedSchema,
+			input:  mixedInput,
+			expect: `resource "foo" "test" {
+  oc          = 1
+  opt_nonzero = 2
+  opt_default = 5
+  opt_nondef  = 7
+}`,
+		},
+		{
+			name:   "RemoveOZeroAttribute only covers primitives and collections",
+			option: TuneOption{RemoveOZeroAttribute: true},
+			schema: tfpluginschema.SchemaBlock{
+				Attributes: []*tfpluginschema.SchemaAttribute{
+					{Name: "number", Type: ToPtr(cty.Number), Optional: true},
+					{Name: "bool", Type: ToPtr(cty.Bool), Optional: true},
+					{Name: "string", Type: ToPtr(cty.String), Optional: true},
+					{Name: "list", Type: ToPtr(cty.List(cty.Number)), Optional: true},
+					{Name: "set", Type: ToPtr(cty.Set(cty.Number)), Optional: true},
+					{Name: "map", Type: ToPtr(cty.Map(cty.Number)), Optional: true},
+				},
+			},
+			input: `resource "foo" "test" {
+  number = 0
+  bool   = false
+  string = ""
+  list   = []
+  set    = []
+  map    = {}
+}`,
+			expect: `resource "foo" "test" {
+}`,
+		},
+		{
+			name:   "RemoveOZeroAttribute only does NOT remove a defaulted attr that happens to be zero",
+			option: TuneOption{RemoveOZeroAttribute: true},
+			schema: tfpluginschema.SchemaBlock{
+				Attributes: []*tfpluginschema.SchemaAttribute{
+					// zero-valued, but schema default is also 0 — belongs to the
+					// "default" bucket, so RemoveOZero alone must NOT remove it.
+					{Name: "opt", Type: ToPtr(cty.Number), Optional: true, Default: 0},
+				},
+			},
+			input: `resource "foo" "test" {
+  opt = 0
+}`,
+			expect: `resource "foo" "test" {
+  opt = 0
+}`,
+		},
+
+		// ---- RemoveODefaultAttribute only ----
+		{
+			name:   "RemoveODefaultAttribute only removes default-valued O and keeps O+C/zero",
+			option: TuneOption{RemoveODefaultAttribute: true},
+			schema: mixedSchema,
+			input:  mixedInput,
+			expect: `resource "foo" "test" {
+  oc          = 1
+  opt_zero    = 0
+  opt_nonzero = 2
+  opt_nondef  = 7
+}`,
+		},
+		{
+			name:   "RemoveODefaultAttribute only covers all primitive/collection default types",
+			option: TuneOption{RemoveODefaultAttribute: true},
+			schema: tfpluginschema.SchemaBlock{
+				Attributes: []*tfpluginschema.SchemaAttribute{
+					{Name: "number", Type: ToPtr(cty.Number), Optional: true, Default: 1},
+					{Name: "bool", Type: ToPtr(cty.Bool), Optional: true, Default: true},
+					{Name: "string", Type: ToPtr(cty.String), Optional: true, Default: "default"},
+					{Name: "list", Type: ToPtr(cty.List(cty.Number)), Optional: true, Default: []interface{}{1}},
+					{Name: "set", Type: ToPtr(cty.Set(cty.Number)), Optional: true, Default: []int{1}},
+					{Name: "map", Type: ToPtr(cty.Map(cty.Number)), Optional: true, Default: map[string]interface{}{"default": 1}},
+				},
+			},
+			input: `resource "foo" "test" {
+  number = 1
+  bool   = true
+  string = "default"
+  list   = [1]
+  set    = [1]
+  map = {
+    default = 1
+  }
+}`,
+			expect: `resource "foo" "test" {
+}`,
+		},
+		{
+			name:   "RemoveODefaultAttribute only does NOT remove a non-default zero value",
+			option: TuneOption{RemoveODefaultAttribute: true},
+			schema: tfpluginschema.SchemaBlock{
+				Attributes: []*tfpluginschema.SchemaAttribute{
+					// zero-valued, no schema default — belongs to the "zero"
+					// bucket, so RemoveODefault alone must NOT remove it.
+					{Name: "opt", Type: ToPtr(cty.Number), Optional: true},
+				},
+			},
+			input: `resource "foo" "test" {
+  opt = 0
+}`,
+			expect: `resource "foo" "test" {
+  opt = 0
+}`,
+		},
+
+		// ---- Combinations of two flags ----
+		{
+			name:   "RemoveOC + RemoveOZeroAttribute keeps default-valued",
+			option: TuneOption{RemoveOC: true, RemoveOZeroAttribute: true},
+			schema: mixedSchema,
+			input:  mixedInput,
+			expect: `resource "foo" "test" {
+  opt_nonzero = 2
+  opt_default = 5
+  opt_nondef  = 7
+}`,
+		},
+		{
+			name:   "RemoveOC + RemoveODefaultAttribute keeps zero-valued",
+			option: TuneOption{RemoveOC: true, RemoveODefaultAttribute: true},
+			schema: mixedSchema,
+			input:  mixedInput,
+			expect: `resource "foo" "test" {
+  opt_zero    = 0
+  opt_nonzero = 2
+  opt_nondef  = 7
+}`,
+		},
+		{
+			name:   "RemoveOZeroAttribute + RemoveODefaultAttribute keeps O+C",
+			option: TuneOption{RemoveOZeroAttribute: true, RemoveODefaultAttribute: true},
+			schema: mixedSchema,
+			input:  mixedInput,
+			expect: `resource "foo" "test" {
+  oc          = 1
+  opt_nonzero = 2
+  opt_nondef  = 7
+}`,
+		},
+
+		// ---- All three flags on (parity with the legacy default mode) ----
+		{
+			name:   "all three flags on trims O+C, zero and default",
+			option: TuneOption{RemoveOC: true, RemoveOZeroAttribute: true, RemoveODefaultAttribute: true},
+			schema: mixedSchema,
+			input:  mixedInput,
+			expect: `resource "foo" "test" {
+  opt_nonzero = 2
+  opt_nondef  = 7
+}`,
+		},
+
+		// ---- Blocks: only RemoveOC affects O+C blocks; the zero/default
+		// flags target attributes only ----
+		{
+			name:   "RemoveOC removes O+C block; zero/default flags do not affect blocks",
+			option: TuneOption{RemoveOC: true},
+			schema: tfpluginschema.SchemaBlock{
+				BlockTypes: []*tfpluginschema.SchemaNestedBlock{
+					{TypeName: "req", Nesting: tfpluginschema.SchemaNestedBlockNestingModeSingle, Required: ToPtr(true)},
+					{TypeName: "oc", Nesting: tfpluginschema.SchemaNestedBlockNestingModeSingle, Optional: ToPtr(true), Computed: ToPtr(true)},
+				},
+			},
+			input: `resource "foo" "test" {
+  req {}
+  oc {}
+}`,
+			expect: `resource "foo" "test" {
+  req {}
+}`,
+		},
+		{
+			name:   "RemoveOZeroAttribute + RemoveODefaultAttribute do not remove O+C blocks",
+			option: TuneOption{RemoveOZeroAttribute: true, RemoveODefaultAttribute: true},
+			schema: tfpluginschema.SchemaBlock{
+				BlockTypes: []*tfpluginschema.SchemaNestedBlock{
+					{TypeName: "req", Nesting: tfpluginschema.SchemaNestedBlockNestingModeSingle, Required: ToPtr(true)},
+					{TypeName: "oc", Nesting: tfpluginschema.SchemaNestedBlockNestingModeSingle, Optional: ToPtr(true), Computed: ToPtr(true)},
+				},
+			},
+			input: `resource "foo" "test" {
+  req {}
+  oc {}
+}`,
+			expect: `resource "foo" "test" {
+  req {}
+  oc {}
+}`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			opt := c.option
+			actual, err := TuneTpl(schema.Schema{Block: &c.schema}, []byte(c.input), &opt)
+			require.NoError(t, err)
+			require.Equal(t, c.expect, string(actual))
+		})
+	}
 }

--- a/tfadd/option.go
+++ b/tfadd/option.go
@@ -2,12 +2,26 @@ package tfadd
 
 type Option struct {
 	// Whether the generated config contains all the non-computed properties?
+	// Equivalent to enabling keepOC, keepZero and keepDefault all at once.
 	// Set via Full option.
 	full bool
 
 	// Whether to mask the sensitive attributes in the generated config?
 	// Set via MaskSensitive option.
 	maskSensitive bool
+
+	// Whether to keep Optional+Computed (O+C) attributes/blocks rather than
+	// trimming them. Set via KeepOC option.
+	keepOC bool
+
+	// Whether to keep Optional attributes whose value equals the type's
+	// "zero" value (used when the schema does not define a default).
+	// Set via KeepZero option.
+	keepZero bool
+
+	// Whether to keep Optional attributes whose value equals the
+	// schema-defined default value. Set via KeepDefault option.
+	keepDefault bool
 }
 
 type OptionSetter interface {
@@ -36,4 +50,46 @@ func MaskSenstitive(b bool) maskSensitiveOption {
 
 func (opt maskSensitiveOption) configureState(cfg *Option) {
 	cfg.maskSensitive = bool(opt)
+}
+
+var _ OptionSetter = keepOCOption(true)
+
+type keepOCOption bool
+
+// KeepOC keeps Optional+Computed (O+C) attributes/blocks rather than
+// trimming them.
+func KeepOC(b bool) keepOCOption {
+	return keepOCOption(b)
+}
+
+func (opt keepOCOption) configureState(cfg *Option) {
+	cfg.keepOC = bool(opt)
+}
+
+var _ OptionSetter = keepZeroOption(true)
+
+type keepZeroOption bool
+
+// KeepZero keeps Optional attributes whose value equals the type's
+// "zero" value (used when the schema does not define a default).
+func KeepZero(b bool) keepZeroOption {
+	return keepZeroOption(b)
+}
+
+func (opt keepZeroOption) configureState(cfg *Option) {
+	cfg.keepZero = bool(opt)
+}
+
+var _ OptionSetter = keepDefaultOption(true)
+
+type keepDefaultOption bool
+
+// KeepDefault keeps Optional attributes whose value equals the
+// schema-defined default value.
+func KeepDefault(b bool) keepDefaultOption {
+	return keepDefaultOption(b)
+}
+
+func (opt keepDefaultOption) configureState(cfg *Option) {
+	cfg.keepDefault = bool(opt)
 }

--- a/tfadd/tfadd_state.go
+++ b/tfadd/tfadd_state.go
@@ -164,41 +164,42 @@ func GenerateForOneResource(rsch *tfjson.Schema, res tfstate.StateResource, opts
 	if err != nil {
 		return nil, fmt.Errorf("generate template from state for %s: %v", res.Type, err)
 	}
-	if !opt.full {
-		providerName := strings.TrimPrefix(res.ProviderName, "registry.terraform.io/")
-		pinfo, ok := supportedProviders[providerName]
-		if !ok {
-			return b, nil
-		}
-		sdkPsch := pinfo.SDKSchema
 
-		sch, err := getTrackedResourceSchema(res, sdkPsch)
-		if err != nil {
-			return nil, err
-		}
+	keepOC := opt.keepOC || opt.full
+	keepZero := opt.keepZero || opt.full
+	keepDefault := opt.keepDefault || opt.full
 
-		if providerName == "azure/azapi" {
-			b, err = internal.TuneTpl(*sch, b, &internal.TuneOption{
-				RemoveOC:          true,
-				RemoveOZAttribute: true,
-				OCToKeep: map[string]bool{
-					"name":      true,
-					"parent_id": true,
-					"identity":  true,
-					"location":  true,
-					"tags":      true,
-					"body":      true,
-				},
-			})
-		} else {
-			b, err = internal.TuneTpl(*sch, b, &internal.TuneOption{
-				RemoveOC:          true,
-				RemoveOZAttribute: true,
-			})
+	providerName := strings.TrimPrefix(res.ProviderName, "registry.terraform.io/")
+	pinfo, ok := supportedProviders[providerName]
+	if !ok {
+		return b, nil
+	}
+	sdkPsch := pinfo.SDKSchema
+
+	sch, err := getTrackedResourceSchema(res, sdkPsch)
+	if err != nil {
+		return nil, err
+	}
+
+	tuneOpt := &internal.TuneOption{
+		RemoveOC:                !keepOC,
+		RemoveOZeroAttribute:    !keepZero,
+		RemoveODefaultAttribute: !keepDefault,
+	}
+	if providerName == "azure/azapi" {
+		tuneOpt.OCToKeep = map[string]bool{
+			"name":      true,
+			"parent_id": true,
+			"identity":  true,
+			"location":  true,
+			"tags":      true,
+			"body":      true,
 		}
-		if err != nil {
-			return nil, fmt.Errorf("tune template for %s: %v", res.Type, err)
-		}
+	}
+
+	b, err = internal.TuneTpl(*sch, b, tuneOpt)
+	if err != nil {
+		return nil, fmt.Errorf("tune template for %s: %v", res.Type, err)
 	}
 	return b, nil
 }


### PR DESCRIPTION
Replace the single default trim mode with three independent toggles: `-keep-oc`, `-keep-zero`, `-keep-default`. `-full` is now a shorthand for all three. Always-on removals (id, timeouts, Computed-only) unchanged.

## Example

```shell
~/tmp/vnet
Γ¥» tfadd state
resource "azurerm_resource_group" "res-0" {
  location = "eastus"
  name     = "magodo-vnet"
}
resource "azurerm_subnet" "res-2" {
  address_prefixes                = ["10.0.0.0/24"]
  default_outbound_access_enabled = false
  name                            = "default"
  resource_group_name             = "magodo-vnet"
  virtual_network_name            = "magodo-test"
}
resource "azurerm_virtual_network" "res-1" {
  address_space       = ["10.0.0.0/16"]
  location            = "eastus"
  name                = "magodo-test"
  resource_group_name = "magodo-vnet"
}


~/tmp/vnet
Γ¥» tfadd state --keep-oc
resource "azurerm_resource_group" "res-0" {
  location = "eastus"
  name     = "magodo-vnet"
}
resource "azurerm_subnet" "res-2" {
  address_prefixes                = ["10.0.0.0/24"]
  default_outbound_access_enabled = false
  name                            = "default"
  resource_group_name             = "magodo-vnet"
  virtual_network_name            = "magodo-test"
}
resource "azurerm_virtual_network" "res-1" {
  address_space       = ["10.0.0.0/16"]
  location            = "eastus"
  name                = "magodo-test"
  resource_group_name = "magodo-vnet"
  subnet = [{
    address_prefixes                              = ["10.0.0.0/24"]
    default_outbound_access_enabled               = false
    delegation                                    = []
    id                                            = "/subscriptions/cb563ee9-7df0-468e-81d5-166968d1f89a/resourceGroups/magodo-vnet/providers/Microsoft.Network/virtualNetworks/magodo-test/subnets/default"
    name                                          = "default"
    private_endpoint_network_policies             = "Disabled"
    private_link_service_network_policies_enabled = true
    route_table_id                                = ""
    security_group                                = ""
    service_endpoint_policy_ids                   = []
    service_endpoints                             = []
  }]
}


~/tmp/vnet
Γ¥» tfadd state --keep-default
resource "azurerm_resource_group" "res-0" {
  location = "eastus"
  name     = "magodo-vnet"
}
resource "azurerm_subnet" "res-2" {
  address_prefixes                              = ["10.0.0.0/24"]
  default_outbound_access_enabled               = false
  name                                          = "default"
  private_endpoint_network_policies             = "Disabled"
  private_link_service_network_policies_enabled = true
  resource_group_name                           = "magodo-vnet"
  virtual_network_name                          = "magodo-test"
}
resource "azurerm_virtual_network" "res-1" {
  address_space                  = ["10.0.0.0/16"]
  location                       = "eastus"
  name                           = "magodo-test"
  private_endpoint_vnet_policies = "Disabled"
  resource_group_name            = "magodo-vnet"
}


~/tmp/vnet
Γ¥» tfadd state --keep-zero
resource "azurerm_resource_group" "res-0" {
  location   = "eastus"
  managed_by = ""
  name       = "magodo-vnet"
  tags       = {}
}
resource "azurerm_subnet" "res-2" {
  address_prefixes                = ["10.0.0.0/24"]
  default_outbound_access_enabled = false
  name                            = "default"
  resource_group_name             = "magodo-vnet"
  service_endpoint_policy_ids     = []
  service_endpoints               = []
  sharing_scope                   = ""
  virtual_network_name            = "magodo-test"
}
resource "azurerm_virtual_network" "res-1" {
  address_space           = ["10.0.0.0/16"]
  bgp_community           = ""
  edge_zone               = ""
  flow_timeout_in_minutes = 0
  location                = "eastus"
  name                    = "magodo-test"
  resource_group_name     = "magodo-vnet"
  tags                    = {}
}
```

(Note in the `--keep-oc` version, there are a few zero values in the `azurerm_virtual_network`'s `subnet` block, which are not trimmed. This is because the subnet is a nested object attribute, `tfadd` currently only supports trimming on primitive types)